### PR TITLE
Do not show more information for empty answers

### DIFF
--- a/app/models/custom/poll/question/answer.rb
+++ b/app/models/custom/poll/question/answer.rb
@@ -7,4 +7,8 @@ class Poll::Question::Answer
   def total_votes
     answers.count + partial_results.sum(:amount)
   end
+
+  def has_more_information?
+    description.present? || documents.any? || images.any? || videos.any?
+  end
 end

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -46,7 +46,7 @@
 
   <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
     <div class="row padding">
-      <% @poll_questions_answers.each do |answer| %>
+      <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
         <div class="small-12 medium-6 column end answer <%= cycle("first", "") %>" id="answer_<%= answer.id %>">
           <h3><%= answer.title %></h3>
 

--- a/spec/models/poll/question/answer_spec.rb
+++ b/spec/models/poll/question/answer_spec.rb
@@ -34,4 +34,30 @@ describe Poll::Question::Answer do
       expect(Poll::Question::Answer.with_content).to be_empty
     end
   end
+
+  describe "has_more_information?" do
+    it "returns false when it has no documents, no images, no videos, nor description" do
+      answer = create(:poll_question_answer, description: nil)
+
+      expect(answer.has_more_information?).to eq(false)
+    end
+
+    it "return true when it has documents, images, videos or description" do
+      answer = create(:poll_question_answer)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_image, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_document, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_document, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+    end
+  end
 end

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -215,6 +215,30 @@ describe "Polls" do
       end
     end
 
+    scenario "Do not show answers without more information at more information section" do
+      question = create(:poll_question, poll: poll)
+      answer_with_description = create(:poll_question_answer, title: "Description", question: question,
+        given_order: 1)
+      answer_with_image = create(:poll_question_answer, :with_image, title: "Image", question: question,
+        given_order: 2)
+      answer_with_document = create(:poll_question_answer, :with_document, title: "Document",
+        question: question, given_order: 3)
+      answer_with_video = create(:poll_question_answer, :with_video, title: "Video", question: question,
+        given_order: 4,)
+      answer_empty = create(:poll_question_answer, title: "Empty", question: question, given_order: 5,
+        description: nil, images: [], documents: [], videos: [])
+
+      visit poll_path(poll)
+
+      within("div.poll-more-info-answers") do
+        expect(page).to have_content(answer_with_description.title)
+        expect(page).to have_content(answer_with_image.title)
+        expect(page).to have_content(answer_with_document.title)
+        expect(page).to have_content(answer_with_video.title)
+        expect(page).not_to have_content(answer_empty.title)
+      end
+    end
+
     scenario "Answer images are shown" do
       question = create(:poll_question, :yes_no, poll: poll)
       create(:image, imageable: question.question_answers.first, title: "The yes movement")


### PR DESCRIPTION
## Objectives
Some answers are clear enough and do not require extra information.

Show answers which have any of the following information defined: description, documents, images or videos.

