### PR TITLE
Avoid render menu in public pages

### DIFF
--- a/app/views/custom/layouts/_header.html.erb
+++ b/app/views/custom/layouts/_header.html.erb
@@ -1,0 +1,52 @@
+<header>
+  <% if display_remote_translation_info?(@remote_translations, I18n.locale) %>
+    <%= render "shared/remote_translations_button", remote_translations: @remote_translations %>
+  <% end %>
+
+  <div class="top-links">
+    <%= render "shared/locale_switcher" %>
+    <div class="hide-for-small-only">
+      <%= render "shared/top_links" %>
+    </div>
+  </div>
+
+  <div class="top-bar">
+    <span data-responsive-toggle="responsive-menu" data-hide-for="medium">
+      <button type="button" class="menu-button" data-toggle>
+        <span class="menu-icon"></span>
+        <%= t("application.menu") %>
+      </button>
+    </span>
+
+    <h1 class="top-bar-title">
+      <%= link_to root_path, accesskey: "0" do %>
+        <%= image_tag(image_path_for("logo_header.png"), alt: setting["org_name"]) %>
+      <% end %>
+    </h1>
+
+    <div id="responsive-menu">
+      <div class="top-bar-right">
+        <ul class="menu" data-responsive-menu="medium-dropdown">
+          <%= render "shared/admin_login_items" %>
+          <%= render "layouts/notification_item" %>
+          <%= render "devise/menu/login_items" %>
+        </ul>
+
+        <div class="show-for-small-only">
+          <div class="subnavigation subnavigation-with-top-links">
+            <%= render "shared/subnavigation" %>
+            <%= render "shared/top_links" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="navigation_bar" class="subnavigation">
+    <div class="hide-for-small-only">
+      <%= render "shared/subnavigation" %>
+    </div>
+
+    <%= yield :header_addon %>
+  </div>
+</header>

--- a/app/views/custom/layouts/_header.html.erb
+++ b/app/views/custom/layouts/_header.html.erb
@@ -26,11 +26,13 @@
 
     <div id="responsive-menu">
       <div class="top-bar-right">
-        <ul class="menu" data-responsive-menu="medium-dropdown">
-          <%= render "shared/admin_login_items" %>
-          <%= render "layouts/notification_item" %>
-          <%= render "devise/menu/login_items" %>
-        </ul>
+        <% if current_user && !current_user.guest || Rails.application.config.sign_in_links %>
+          <ul class="menu" data-responsive-menu="medium-dropdown">
+            <%= render "shared/admin_login_items" %>
+            <%= render "layouts/notification_item" %>
+            <%= render "devise/menu/login_items" %>
+          </ul>
+        <% end %>
 
         <div class="show-for-small-only">
           <div class="subnavigation subnavigation-with-top-links">

--- a/config/application_custom.rb
+++ b/config/application_custom.rb
@@ -1,5 +1,6 @@
 module Consul
   class Application < Rails::Application
     config.autoload_paths << "#{Rails.root}/app/controllers/custom/concerns"
+    config.sign_in_links = Rails.env.test?
   end
 end

--- a/spec/custom_spec_helper.rb
+++ b/spec/custom_spec_helper.rb
@@ -6,4 +6,15 @@ RSpec.configure do |config|
   # Using this tag will help maintaining the test suite when doing
   # custom changes and when upgrading to a newer version of CONSUL
   config.filter_run_excluding consul: true
+
+  config.around(:each, :disable_sign_in_links) do |example|
+    default_sign_in_config = Rails.application.config.sign_in_links
+    Rails.application.config.sign_in_links = false
+
+    begin
+      example.run
+    ensure
+      Rails.application.config.sign_in_links = default_sign_in_config
+    end
+  end
 end

--- a/spec/system/custom/sign_in_links_spec.rb
+++ b/spec/system/custom/sign_in_links_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "Sign in links", :disable_sign_in_links do
+  context "Page using guest users" do
+    scenario "Does not render for guest users" do
+      visit polls_path
+
+      expect(page).not_to have_link "Sign in"
+      expect(page).not_to have_link "Register"
+      expect(page).not_to have_link "My content"
+      expect(page).not_to have_link "My account"
+    end
+
+    scenario "Does render for identified users" do
+      login_as(create(:administrator).user)
+
+      visit polls_path
+
+      expect(page).to have_link "Menu"
+      expect(page).to have_link "My content"
+      expect(page).to have_link "My account"
+    end
+  end
+
+  context "Page not using guest users" do
+    scenario "Does not render for anonymous users" do
+      visit root_path
+
+      expect(page).not_to have_link "Sign in"
+      expect(page).not_to have_link "Register"
+      expect(page).not_to have_link "My content"
+      expect(page).not_to have_link "My account"
+    end
+
+    scenario "Does render for identified users" do
+      login_as(create(:user))
+
+      visit root_path
+
+      expect(page).to have_link "My content"
+      expect(page).to have_link "My account"
+    end
+  end
+end


### PR DESCRIPTION
## Objectives
As it is an anonymous vote and there is no need to register on the platform, we hide the links in the menu for notifications, sign in and sign up.

We will keep the menu exactly the same for the administration section.

## Visual Changes
![Public pages without menu](https://user-images.githubusercontent.com/16189/161591218-43c5b8e4-7b80-4fcf-88d4-0cce8a2f2d01.png)

## Notes
To access the administration section, you will have to manually access the `/admin` path.