### PR TITLE
Hide unneeded sections

### DIFF
--- a/app/components/custom/admin/menu_component.html.erb
+++ b/app/components/custom/admin/menu_component.html.erb
@@ -1,0 +1,134 @@
+<ul id="admin_menu" data-accordion-menu data-multi-open="true">
+  <% if feature?(:proposals) %>
+    <li class="<%= "is-active" if controller_name == "proposals" %>">
+      <%= link_to t("admin.menu.proposals"), admin_proposals_path, class: "proposals-link" %>
+    </li>
+  <% end %>
+
+  <% if feature?(:debates) %>
+    <li class="<%= "is-active" if controller_name == "debates" %>">
+      <%= link_to t("admin.menu.debates"), admin_debates_path, class: "debates-link" %>
+    </li>
+  <% end %>
+
+  <li class="<%= "is-active" if controller_name == "comments" %>">
+    <%= link_to t("admin.menu.comments"), admin_comments_path, class: "comments-link" %>
+  </li>
+
+  <% if feature?(:polls) %>
+    <li class="<%= "is-active" if polls? %>">
+      <%= link_to t("admin.menu.polls"), admin_polls_path, class: "polls-link" %>
+    </li>
+  <% end %>
+
+  <% if feature?(:legislation) %>
+    <li class="<%= "is-active" if controller.class.parent == Admin::Legislation %>">
+      <%= link_to t("admin.menu.legislation"), admin_legislation_processes_path, class: "legislation-link" %>
+    </li>
+  <% end %>
+
+  <% if feature?(:budgets) %>
+    <li class="<%= "is-active" if budgets? %>">
+      <%= link_to t("admin.menu.budgets"), admin_budgets_path, class: "budgets-link" %>
+    </li>
+  <% end %>
+
+  <li>
+    <a href="#" class="booths-link"><%= t("admin.menu.title_booths") %></a>
+    <%= link_list(
+      officers_link,
+      booths_link,
+      booth_assignments_link,
+      shifts_link,
+      id: "booths_menu", class: ("is-active" if booths?)
+    ) %>
+  </li>
+
+  <% if feature?(:signature_sheets) %>
+    <li class="<%= "is-active" if controller_name == "signature_sheets" %>">
+      <%= link_to t("admin.menu.signature_sheets"), admin_signature_sheets_path, class: "signature-sheets-link" %>
+    </li>
+  <% end %>
+
+  <li>
+    <a href="#" class="messages-link"><%= t("admin.menu.messaging_users") %></a>
+    <%= link_list(
+      newsletters_link,
+      admin_notifications_link,
+      system_emails_link,
+      emails_download_link,
+      id: "messaging_users_menu", class: ("is-active" if messages_menu_active?)
+    ) %>
+  </li>
+
+  <li>
+    <a href="#" class="site-customization-link"><%= t("admin.menu.title_site_customization") %></a>
+    <%= link_list(
+      homepage_link,
+      pages_link,
+      banners_link,
+      information_texts_link,
+      documents_link,
+      class: ("is-active" if customization? && controller.class.parent != Admin::Poll::Questions::Answers)
+    ) %>
+  </li>
+
+  <li>
+    <a href="#" class="moderated-content-link"><%= t("admin.menu.title_moderated_content") %></a>
+    <%= link_list(
+      (hidden_proposals_link if feature?(:proposals)),
+      (hidden_debates_link if feature?(:debates)),
+      (hidden_budget_investments_link if feature?(:budgets)),
+      hidden_comments_link,
+      hidden_proposal_notifications_link,
+      hidden_users_link,
+      activity_link,
+      class: ("is-active" if moderated_content?)
+    ) %>
+  </li>
+
+  <li>
+    <a href="#" class="profiles-link"><%= t("admin.menu.title_profiles") %></a>
+    <%= link_list(
+      administrators_link,
+      organizations_link,
+      officials_link,
+      moderators_link,
+      valuators_link,
+      managers_link,
+      (sdg_managers_link if feature?(:sdg)),
+      users_link,
+      class: ("is-active" if profiles?)
+    ) %>
+  </li>
+
+  <li class="<%= "is-active" if controller_name == "stats" %>">
+    <%= link_to t("admin.menu.stats"), admin_stats_path, class: "stats-link" %>
+  </li>
+
+  <li>
+    <a href="#" class="settings-link"><%= t("admin.menu.title_settings") %></a>
+    <%= link_list(
+      settings_link,
+      tags_link,
+      geozones_link,
+      images_link,
+      content_blocks_link,
+      local_census_records_link,
+      class: ("is-active" if settings?)
+    ) %>
+  </li>
+  <li>
+    <a href="#" class="dashboard-link"><%= t("admin.menu.dashboard") %></a>
+    <%= link_list(
+      dashboard_actions_link,
+      administrator_tasks_link,
+      class: ("is-active" if dashboard?)
+    ) %>
+  </li>
+  <% if ::MachineLearning.enabled? %>
+    <li class="<%= "is-active" if controller_name == "machine_learning" %>">
+      <%= link_to t("admin.menu.machine_learning"), admin_machine_learning_path, class: "ml-link" %>
+    </li>
+  <% end %>
+</ul>

--- a/app/components/custom/admin/menu_component.html.erb
+++ b/app/components/custom/admin/menu_component.html.erb
@@ -11,10 +11,6 @@
     </li>
   <% end %>
 
-  <li class="<%= "is-active" if controller_name == "comments" %>">
-    <%= link_to t("admin.menu.comments"), admin_comments_path, class: "comments-link" %>
-  </li>
-
   <% if feature?(:polls) %>
     <li class="<%= "is-active" if polls? %>">
       <%= link_to t("admin.menu.polls"), admin_polls_path, class: "polls-link" %>
@@ -33,33 +29,11 @@
     </li>
   <% end %>
 
-  <li>
-    <a href="#" class="booths-link"><%= t("admin.menu.title_booths") %></a>
-    <%= link_list(
-      officers_link,
-      booths_link,
-      booth_assignments_link,
-      shifts_link,
-      id: "booths_menu", class: ("is-active" if booths?)
-    ) %>
-  </li>
-
   <% if feature?(:signature_sheets) %>
     <li class="<%= "is-active" if controller_name == "signature_sheets" %>">
       <%= link_to t("admin.menu.signature_sheets"), admin_signature_sheets_path, class: "signature-sheets-link" %>
     </li>
   <% end %>
-
-  <li>
-    <a href="#" class="messages-link"><%= t("admin.menu.messaging_users") %></a>
-    <%= link_list(
-      newsletters_link,
-      admin_notifications_link,
-      system_emails_link,
-      emails_download_link,
-      id: "messaging_users_menu", class: ("is-active" if messages_menu_active?)
-    ) %>
-  </li>
 
   <li>
     <a href="#" class="site-customization-link"><%= t("admin.menu.title_site_customization") %></a>
@@ -74,29 +48,9 @@
   </li>
 
   <li>
-    <a href="#" class="moderated-content-link"><%= t("admin.menu.title_moderated_content") %></a>
-    <%= link_list(
-      (hidden_proposals_link if feature?(:proposals)),
-      (hidden_debates_link if feature?(:debates)),
-      (hidden_budget_investments_link if feature?(:budgets)),
-      hidden_comments_link,
-      hidden_proposal_notifications_link,
-      hidden_users_link,
-      activity_link,
-      class: ("is-active" if moderated_content?)
-    ) %>
-  </li>
-
-  <li>
     <a href="#" class="profiles-link"><%= t("admin.menu.title_profiles") %></a>
     <%= link_list(
       administrators_link,
-      organizations_link,
-      officials_link,
-      moderators_link,
-      valuators_link,
-      managers_link,
-      (sdg_managers_link if feature?(:sdg)),
       users_link,
       class: ("is-active" if profiles?)
     ) %>
@@ -110,22 +64,12 @@
     <a href="#" class="settings-link"><%= t("admin.menu.title_settings") %></a>
     <%= link_list(
       settings_link,
-      tags_link,
-      geozones_link,
       images_link,
       content_blocks_link,
-      local_census_records_link,
       class: ("is-active" if settings?)
     ) %>
   </li>
-  <li>
-    <a href="#" class="dashboard-link"><%= t("admin.menu.dashboard") %></a>
-    <%= link_list(
-      dashboard_actions_link,
-      administrator_tasks_link,
-      class: ("is-active" if dashboard?)
-    ) %>
-  </li>
+
   <% if ::MachineLearning.enabled? %>
     <li class="<%= "is-active" if controller_name == "machine_learning" %>">
       <%= link_to t("admin.menu.machine_learning"), admin_machine_learning_path, class: "ml-link" %>

--- a/app/components/custom/admin/menu_component.rb
+++ b/app/components/custom/admin/menu_component.rb
@@ -1,0 +1,6 @@
+class Admin::MenuComponent < ApplicationComponent; end
+
+require_dependency Rails.root.join("app", "components", "admin", "menu_component").to_s
+
+class Admin::MenuComponent < ApplicationComponent
+end

--- a/app/controllers/custom/admin/stats_controller.rb
+++ b/app/controllers/custom/admin/stats_controller.rb
@@ -1,0 +1,7 @@
+require_dependency Rails.root.join("app", "controllers", "admin", "stats_controller").to_s
+
+class Admin::StatsController < Admin::BaseController
+  def show
+    redirect_to polls_admin_stats_path
+  end
+end

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -110,14 +110,4 @@
       <% end %>
     </div>
   </div>
-
-  <% if !current_user&.guest? %>
-    <div class="tabs-content" data-tabs-content="polls_tabs">
-      <%= render "filter_subnav" %>
-
-      <div class="tabs-panel is-active" id="tab-comments">
-        <%= render "comments" %>
-      </div>
-    </div>
-  <% end %>
 </div>

--- a/app/views/custom/shared/_admin_login_items.html.erb
+++ b/app/views/custom/shared/_admin_login_items.html.erb
@@ -1,0 +1,43 @@
+<% if show_admin_menu?(current_user) %>
+  <li class="has-submenu">
+    <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+    <ul class="submenu menu" data-submenu>
+      <% if current_user.administrator? %>
+        <li>
+          <%= link_to t("layouts.header.administration"), admin_root_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.administrator? || current_user.moderator? %>
+        <li>
+          <%= link_to t("layouts.header.moderation"), moderation_root_path %>
+        </li>
+      <% end %>
+
+      <% if feature?(:budgets) &&
+            (current_user.administrator? || current_user.valuator?) %>
+        <li>
+          <%= link_to t("layouts.header.valuation"), valuation_root_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.administrator? || current_user.manager? %>
+        <li>
+          <%= link_to t("layouts.header.management"), management_sign_in_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.poll_officer? && Poll.current.any? %>
+        <li>
+          <%= link_to t("layouts.header.officing"), officing_root_path %>
+        </li>
+      <% end %>
+
+      <% if feature?(:sdg) && (current_user.administrator? || current_user.sdg_manager?) %>
+        <li>
+          <%= link_to t("sdg_management.header.title"), sdg_management_root_path %>
+        </li>
+      <% end %>
+    </ul>
+  </li>
+<% end %>

--- a/app/views/custom/shared/_admin_login_items.html.erb
+++ b/app/views/custom/shared/_admin_login_items.html.erb
@@ -8,22 +8,10 @@
         </li>
       <% end %>
 
-      <% if current_user.administrator? || current_user.moderator? %>
-        <li>
-          <%= link_to t("layouts.header.moderation"), moderation_root_path %>
-        </li>
-      <% end %>
-
       <% if feature?(:budgets) &&
             (current_user.administrator? || current_user.valuator?) %>
         <li>
           <%= link_to t("layouts.header.valuation"), valuation_root_path %>
-        </li>
-      <% end %>
-
-      <% if current_user.administrator? || current_user.manager? %>
-        <li>
-          <%= link_to t("layouts.header.management"), management_sign_in_path %>
         </li>
       <% end %>
 

--- a/spec/system/admin/comments_spec.rb
+++ b/spec/system/admin/comments_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Admin comments", :admin do
+describe "Admin comments", :admin, :consul do
   scenario "Index" do
     create(:comment, body: "Everything is awesome")
 

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -11,7 +11,7 @@ describe "Admin geozones", :admin do
     expect(page).to have_content(retiro.name)
   end
 
-  scenario "Create new geozone" do
+  scenario "Create new geozone", :consul do
     visit admin_root_path
 
     within("#side_menu") do

--- a/spec/system/admin/poll/booths_spec.rb
+++ b/spec/system/admin/poll/booths_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin booths", :admin do
-  scenario "Index empty" do
+  scenario "Index empty", :consul do
     visit admin_root_path
 
     within("#side_menu") do
@@ -12,7 +12,7 @@ describe "Admin booths", :admin do
     expect(page).to have_content "There are no active booths for any upcoming poll."
   end
 
-  scenario "Index" do
+  scenario "Index", :consul do
     3.times { create(:poll_booth) }
 
     visit admin_root_path
@@ -32,7 +32,7 @@ describe "Admin booths", :admin do
     expect(page).not_to have_content "There are no booths"
   end
 
-  scenario "Available" do
+  scenario "Available", :consul do
     booth_for_current_poll = create(:poll_booth, polls: [create(:poll, :current)])
     booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
 

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Stats", :admin do
+describe "Stats", :admin, :consul do
   context "Summary" do
     scenario "General" do
       create(:debate)

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -68,7 +68,7 @@ describe "Admin" do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Admin access links", :admin do
+  scenario "Admin access links", :admin, :consul do
     Setting["feature.sdg"] = true
 
     visit root_path

--- a/spec/system/campaigns_spec.rb
+++ b/spec/system/campaigns_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Email campaigns", :admin do
+describe "Email campaigns", :admin, :consul do
   let!(:campaign1) { create(:campaign) }
   let!(:campaign2) { create(:campaign) }
 

--- a/spec/system/ckeditor_spec.rb
+++ b/spec/system/ckeditor_spec.rb
@@ -51,7 +51,7 @@ describe "CKEditor" do
     expect(page).not_to have_link "Browse Server"
   end
 
-  context "When navigating back to editor page using browser history back" do
+  context "When navigating back to editor page using browser history back", :consul do
     scenario "display ckeditor unsaved contents", :admin do
       visit new_admin_newsletter_path
       fill_in_ckeditor "Email content", with: "This is an unsaved body"

--- a/spec/system/custom/admin/stats_spec.rb
+++ b/spec/system/custom/admin/stats_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe "Stats", :admin do
+  context "Polls" do
+    scenario "Total participants by origin" do
+      create(:poll_officer_assignment)
+      3.times { create(:poll_voter, origin: "web") }
+
+      visit polls_admin_stats_path
+
+      within("#web_participants") do
+        expect(page).to have_content "3"
+      end
+    end
+
+    scenario "Total participants" do
+      user = create(:user, :level_two)
+      3.times { create(:poll_voter, user: user) }
+      create(:poll_voter)
+
+      visit polls_admin_stats_path
+
+      within("#participants") do
+        expect(page).to have_content "2"
+      end
+    end
+
+    scenario "Participants by poll" do
+      poll1 = create(:poll)
+      poll2 = create(:poll)
+
+      1.times { create(:poll_voter, poll: poll1, origin: "web") }
+      2.times { create(:poll_voter, poll: poll2, origin: "web") }
+
+      visit polls_admin_stats_path
+
+      within("#polls") do
+        within("#poll_#{poll1.id}") do
+          expect(page).to have_content "1"
+        end
+
+        within("#poll_#{poll2.id}") do
+          expect(page).to have_content "2"
+        end
+      end
+    end
+
+    scenario "Participants by poll question" do
+      user1 = create(:user, :level_two)
+      user2 = create(:user, :level_two)
+
+      poll = create(:poll)
+
+      question1 = create(:poll_question, :yes_no, poll: poll)
+      question2 = create(:poll_question, :yes_no, poll: poll)
+
+      create(:poll_answer, question: question1, author: user1)
+      create(:poll_answer, question: question2, author: user1)
+      create(:poll_answer, question: question2, author: user2)
+
+      visit polls_admin_stats_path
+
+      within("#poll_question_#{question1.id}") do
+        expect(page).to have_content "1"
+      end
+
+      within("#poll_question_#{question2.id}") do
+        expect(page).to have_content "2"
+      end
+
+      within("#poll_#{poll.id}_questions_total") do
+        expect(page).to have_content "2"
+      end
+    end
+  end
+end

--- a/spec/system/custom/admin_spec.rb
+++ b/spec/system/custom/admin_spec.rb
@@ -13,4 +13,36 @@ describe "Admin" do
     expect(page).not_to have_link("Management")
     expect(page).not_to have_link("Moderation")
   end
+
+  scenario "Admin sidebar navigation links", :admin do
+    visit admin_root_path
+
+    within "#side_menu" do
+      expect(page).not_to have_link("Comments")
+      expect(page).not_to have_link("Voting booths")
+      expect(page).not_to have_link("Messages to users")
+      expect(page).not_to have_link("Moderated content")
+      expect(page).not_to have_link("Proposals dashboard")
+
+      click_link "Profiles"
+
+      expect(page).to have_link("Administrators")
+      expect(page).to have_link("Users")
+      expect(page).not_to have_link("Organisations")
+      expect(page).not_to have_link("Officials")
+      expect(page).not_to have_link("Moderators")
+      expect(page).not_to have_link("Valuators")
+      expect(page).not_to have_link("Managers")
+      expect(page).not_to have_link("SDG Managers")
+
+      click_link "Settings"
+
+      expect(page).to have_link("Global settings")
+      expect(page).to have_link("Custom images")
+      expect(page).to have_link("Custom content blocks")
+      expect(page).not_to have_link("Proposals topics")
+      expect(page).not_to have_link("Manage geozones")
+      expect(page).not_to have_link("Manage local census")
+    end
+  end
 end

--- a/spec/system/custom/admin_spec.rb
+++ b/spec/system/custom/admin_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe "Admin" do
+  scenario "Admin access links", :admin do
+    Setting["feature.sdg"] = true
+
+    visit root_path
+    click_link "Menu"
+
+    expect(page).to have_link("Administration")
+    expect(page).to have_link("Valuation")
+    expect(page).to have_link("SDG content")
+    expect(page).not_to have_link("Management")
+    expect(page).not_to have_link("Moderation")
+  end
+end

--- a/spec/system/custom/ckeditor_spec.rb
+++ b/spec/system/custom/ckeditor_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "CKEditor" do
+  context "When navigating back to editor page using browser history back" do
+    scenario "display ckeditor unsaved contents", :admin do
+      visit new_admin_newsletter_path
+      fill_in_ckeditor "Email content", with: "This is an unsaved body"
+      click_link "Go back"
+
+      expect(page).to have_link "New newsletter"
+
+      go_back
+
+      expect(page).to have_ckeditor "Email content", with: "This is an unsaved body"
+    end
+  end
+end

--- a/spec/system/custom/comments/polls_spec.rb
+++ b/spec/system/custom/comments/polls_spec.rb
@@ -3,9 +3,19 @@ require "rails_helper"
 describe "Commenting polls" do
   let(:poll) { create(:poll) }
 
-  scenario "is not available for guest users" do
-    visit poll_path(poll)
+  context "Does not render comments section" do
+    scenario "For users guests" do
+      visit poll_path(poll)
 
-    expect(page).not_to have_link "Comments (0)"
+      expect(page).not_to have_content "Comments"
+    end
+
+    scenario "For identified users" do
+      login_as(create(:administrator).user)
+
+      visit poll_path(poll)
+
+      expect(page).not_to have_content "Comments"
+    end
   end
 end

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -148,7 +148,7 @@ describe "Emails" do
     end
   end
 
-  context "Poll comments" do
+  context "Poll comments", :consul do
     let(:user) { create(:user, email_on_comment: true) }
     let(:poll) { create(:poll, author: user) }
 
@@ -432,7 +432,7 @@ describe "Emails" do
     end
   end
 
-  context "Polls" do
+  context "Polls", :consul do
     scenario "Send email on poll comment reply" do
       user1 = create(:user, email_on_comment_reply: true)
       user2 = create(:user)

--- a/spec/system/management_spec.rb
+++ b/spec/system/management_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Management" do
+describe "Management", :consul do
   let(:user) { create(:user) }
 
   scenario "Should show admin menu if logged user is admin" do

--- a/spec/system/moderation_spec.rb
+++ b/spec/system/moderation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Moderation" do
+describe "Moderation", :consul do
   let(:user) { create(:user) }
 
   scenario "Access as regular user is not authorized" do

--- a/spec/system/officing_spec.rb
+++ b/spec/system/officing_spec.rb
@@ -18,7 +18,7 @@ describe "Poll Officing" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as moderator is not authorized" do
+  scenario "Access as moderator is not authorized", :consul do
     create(:moderator, user: user)
 
     login_as(user)
@@ -35,7 +35,7 @@ describe "Poll Officing" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as manager is not authorized" do
+  scenario "Access as manager is not authorized", :consul do
     create(:manager, user: user)
 
     login_as(user)

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Polls" do
-  context "Concerns" do
+  context "Concerns", :consul do
     it_behaves_like "notifiable in-app", :poll
   end
 


### PR DESCRIPTION
## Objectives
Hide unneeded sections:
- Disable comments on polls for admins
- Disable moderator and management sections from admin top menu
- Disable unneeded sections on admin sidebar
- Render polls directly when access to statistics page from backend.

## Visual Changes
- Before:
![Admin section with unneeded sections](https://user-images.githubusercontent.com/16189/161822659-ca83d3df-f028-4888-aa19-d3c3815b3433.png)

- After:
![Admin section without unneeded sections](https://user-images.githubusercontent.com/16189/161822739-d3094899-7cc0-484e-a39b-cd65d0d31462.png)

## Notes
To avoid having to modify/skip all the specs that would break with these changes, we make all these sections visible in tests, but hidden in a development or production environment.