### PR TITLE
Allow administrators to destroy poll question answers

### DIFF
--- a/app/controllers/custom/admin/poll/questions/answers_controller.rb
+++ b/app/controllers/custom/admin/poll/questions/answers_controller.rb
@@ -1,0 +1,17 @@
+require_dependency Rails.root.join("app", "controllers", "admin", "poll", "questions", "answers_controller").to_s
+
+class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
+  skip_before_action :load_answer
+  before_action :load_answer, only: [:show, :edit, :update, :documents, :destroy]
+
+  def destroy
+    if can?(:destroy, @answer)
+      @answer.destroy!
+      redirect_to admin_question_path(@answer.question),
+        notice: t("flash.actions.destroy.poll_question_answer.success")
+    else
+      redirect_to admin_question_path(@answer.question),
+        alert: t("flash.actions.destroy.poll_question_answer.error")
+    end
+  end
+end

--- a/app/models/custom/abilities/administrator.rb
+++ b/app/models/custom/abilities/administrator.rb
@@ -1,0 +1,13 @@
+require_dependency Rails.root.join("app", "models", "abilities", "administrator").to_s
+
+class Abilities::Administrator
+  alias_method :consul_initialize, :initialize
+
+  def initialize(user)
+    consul_initialize(user)
+
+    can :destroy, Poll::Question::Answer do |answer|
+      answer.answers.none? && answer.partial_results.none?
+    end
+  end
+end

--- a/app/views/custom/admin/poll/questions/show.html.erb
+++ b/app/views/custom/admin/poll/questions/show.html.erb
@@ -42,7 +42,7 @@
 
 <table class="margin-top">
   <tr>
-    <th colspan="5" scope="col" class="with-button">
+    <th colspan="6" scope="col" class="with-button">
       <%= t("admin.questions.show.valid_answers") %>
     </th>
   </tr>
@@ -53,6 +53,7 @@
     <th scope="col" class="text-center"><%= t("admin.questions.show.answers.images") %></th>
     <th scope="col" class="text-center"><%= t("admin.questions.show.answers.documents") %></th>
     <th scope="col" class="text-center"><%= t("admin.questions.show.answers.videos") %></th>
+    <th scope="col" class="text-center"><%= t("admin.actions.actions") %></th>
   </tr>
 
   <tbody class="sortable" data-js-url="<%= admin_question_answers_order_answers_path(@question.id) %>">
@@ -77,6 +78,11 @@
           <br>
           <%= link_to t("admin.questions.show.answers.video_list"),
                       admin_answer_videos_path(answer) %>
+        </td>
+        <td class="text-center">
+          <%= render Admin::TableActionsComponent.new(answer, actions: []) do |actions| %>
+            <%= actions.action(:destroy, path: admin_answer_path(answer), method: :delete, confirm: true) %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/config/locales/custom/en/responders.yml
+++ b/config/locales/custom/en/responders.yml
@@ -1,0 +1,7 @@
+en:
+  flash:
+    actions:
+      destroy:
+        poll_question_answer:
+          error: Cannot delete poll question answer because it already has user answers!
+          success: Poll question answer deleted successfully!

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -170,7 +170,7 @@ namespace :admin do
     end
 
     resources :questions, shallow: true do
-      resources :answers, except: [:index, :destroy], controller: "questions/answers" do
+      resources :answers, except: [:index], controller: "questions/answers" do
         resources :images, controller: "questions/answers/images"
         resources :videos, controller: "questions/answers/videos"
         get :documents, to: "questions/answers#documents"

--- a/spec/models/custom/abilities/administrator_spec.rb
+++ b/spec/models/custom/abilities/administrator_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require "cancan/matchers"
+
+describe Abilities::Administrator do
+  subject(:ability) { Ability.new(user) }
+
+  let(:user) { administrator.user }
+  let(:administrator) { create(:administrator) }
+  let(:other_user) { create(:user) }
+  let(:poll_question_answer_with_answers) { create(:poll_question_answer) }
+  let(:poll_question_answer_with_partial_results) { create(:poll_question_answer) }
+
+  before do
+    create(:poll_answer, question: poll_question_answer_with_answers.question,
+                         answer: poll_question_answer_with_answers)
+    create(:poll_partial_result, question: poll_question_answer_with_partial_results.question,
+                                 answer: poll_question_answer_with_partial_results)
+  end
+
+  it { should be_able_to(:destroy, Poll::Question::Answer) }
+  it { should_not be_able_to(:destroy, poll_question_answer_with_answers) }
+  it { should_not be_able_to(:destroy, poll_question_answer_with_partial_results) }
+end

--- a/spec/system/custom/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/system/custom/admin/poll/questions/answers/answers_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Answers", :admin do
+  scenario "can destroy poll question answers when it has no related answers" do
+    poll_question_answer = create(:poll_question_answer)
+
+    visit admin_question_path(poll_question_answer.question)
+
+    accept_confirm { click_button "Delete" }
+
+    expect(page).to have_content("Poll question answer deleted successfully!")
+  end
+
+  scenario "cannot destroy poll question answers it has related answers" do
+    poll_question_answer = create(:poll_question_answer)
+    create(:poll_answer, question: poll_question_answer.question, answer: poll_question_answer)
+
+    visit admin_question_path(poll_question_answer.question)
+
+    accept_confirm { click_button "Delete" }
+
+    expect(page).to have_content("Cannot delete poll question answer because it already has user answers!")
+  end
+
+  scenario "cannot destroy poll question answers it has related partial results" do
+    poll_question_answer = create(:poll_question_answer)
+    create(:poll_partial_result, question: poll_question_answer.question, answer: poll_question_answer)
+
+    visit admin_question_path(poll_question_answer.question)
+
+    accept_confirm { click_button "Delete" }
+
+    expect(page).to have_content("Cannot delete poll question answer because it already has user answers!")
+  end
+end


### PR DESCRIPTION
Only when the poll questions answers has not associated answers or
partial results.

## References

This PR Depends on:
* #14 

## Objectives

Allow administrators to remove poll question answers when it doesn't have associated answers or partial results.

CONSUL does not allow to do this in any case 🤔 .

## Visual Changes
**Before**
<img width="1306" alt="Captura de Pantalla 2022-05-09 a las 14 05 49" src="https://user-images.githubusercontent.com/15726/167406421-d6bac8c0-feeb-4f5f-a37a-6cd1be6f667e.png">

**After**
<img width="1319" alt="Captura de Pantalla 2022-05-09 a las 14 05 23" src="https://user-images.githubusercontent.com/15726/167406517-23d61bf6-a945-4869-92f5-d67d4822f7da.png">
