### PR TITLE
Simplify poll question answers more information section

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -23,3 +23,9 @@
     margin-bottom: 0;
   }
 }
+
+.poll-more-info-answers {
+  .column:nth-child(odd) {
+    border-right: 0;
+  }
+}

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -56,21 +56,8 @@
 
           <% if answer.description.present? %>
             <div class="margin-top">
-              <div id="answer_description_<%= answer.id %>" class="answer-description short" data-toggler="short">
+              <div id="answer_description_<%= answer.id %>" class="answer-description">
                 <%= wysiwyg(answer.description) %>
-              </div>
-              <div class="read-more">
-                <button type="button" id="read_more_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide">
-                  <%= t("polls.show.read_more", answer: answer.title) %>
-                </button>
-                <button type="button" id="read_less_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide"
-                   class="hide">
-                  <%= t("polls.show.read_less", answer: answer.title) %>
-                </button>
               </div>
             </div>
           <% end %>

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -47,7 +47,7 @@
   <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
     <div class="row padding">
       <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
-        <div class="small-12 medium-6 column end answer <%= cycle("first", "") %>" id="answer_<%= answer.id %>">
+        <div class="small-12 column end answer" id="answer_<%= answer.id %>">
           <h3><%= answer.title %></h3>
 
           <% if answer.images.any? %>


### PR DESCRIPTION
## Objectives

* Use a full row for each poll question answer.
* Remove togglers

## Visual Changes

**Before**
<img width="1075" alt="Captura de Pantalla 2022-05-09 a las 16 16 12" src="https://user-images.githubusercontent.com/15726/167429851-4fdee561-1492-4ef6-b5fd-68e7ac462957.png">

**After**
<img width="1066" alt="Captura de Pantalla 2022-05-09 a las 16 15 50" src="https://user-images.githubusercontent.com/15726/167429854-0215a31d-e97f-4759-b891-f499f647497d.png">

