### PR TITLE
Add missing translations

### DIFF
--- a/config/locales/custom/ar/activerecord.yml
+++ b/config/locales/custom/ar/activerecord.yml
@@ -1,0 +1,5 @@
+ar:
+  activerecord:
+    attributes:
+      poll/answer:
+        answer_id: "إجابه"

--- a/config/locales/custom/ar/general.yml
+++ b/config/locales/custom/ar/general.yml
@@ -2,3 +2,24 @@ ar:
   layouts:
     footer:
       consul_url: https://github.com/rockandror/innoviris-consul
+      funding:
+        text: "تلقى هذا المشروع تمويلًا من برنامج Horizon 2020 للبحث والابتكار التابع للاتحاد الأوروبي بموجب اتفاقية المنحة رقم 872441."
+        logo: "شعار الاتحاد الأوروبي"
+      framework:
+        link: "قم بزيارة Pro-Ethics framework pro-ethics.eu"
+        logo: "شعار Pro-Ethics"
+  polls:
+    answers:
+      create:
+        success_notice: "تم حفظ الاستطلاع بنجاح!"
+      form:
+        submit_button: "تصويت"
+        error:
+          one: "خطأ واحد حال دون حفظ إجاباتك. يرجى التحقق من الحقل المحدد لمعرفة كيفية تصحيحه:"
+          other: "%{count} أخطاء حالت دون حفظ إجاباتك. يرجى التحقق من الحقول المحددة لمعرفة كيفية تصحيحها:"
+        terms_of_service:
+          terms: "من خلال إجابتك فإنك توافق على٪ {terms}"
+          title: "من خلال إجابتك فإنك توافق على شروط وأحكام الاستخدام"
+        postal_code_validator: "تنسيق الرمز البريدي غير صالح. يجب أن تحتوي الرموز البريدية المسموح بها على أربعة أرقام."
+    show:
+      answers_descriptions_link_text: "اقرأ أكثر"

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,6 +1,8 @@
 en:
   activerecord:
     attributes:
+      poll/answer:
+        answer_id: "Answer"
       poll/question:
         mandatory_answer: "Mandatory answer"
       poll/question/translation:

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,0 +1,5 @@
+es:
+  activerecord:
+    attributes:
+      poll/answer:
+        answer_id: "La respuesta"

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -8,3 +8,18 @@ es:
       framework:
         link: "Visita la página de Pro-Ethics en pro-ethics.eu"
         logo: "Logotipo de Pro-Ethics"
+  polls:
+    answers:
+      create:
+        success_notice: "Votación guardada correctamente."
+      form:
+        submit_button: "Votar"
+        error:
+          one: "1 error ha impedido que se guarden tus respuestas. Por favor, comprueba el campo marcado para saber cómo corregirlo:"
+          other: "%{count} errores han impedido que se guarden tus respuestas. Por favor, comprueba los campos marcados para saber cómo corregirlos:"
+        terms_of_service:
+          terms: "Al responder aceptas los %{terms}"
+          title: "Al responder aceptas los términos y condiciones de uso"
+        postal_code_validator: "El formato del código postal es inválido. Los códigos postales permitidos deben contener cuatro dígitos."
+    show:
+      answers_descriptions_link_text: "Leer más"

--- a/config/locales/custom/fr/activerecord.yml
+++ b/config/locales/custom/fr/activerecord.yml
@@ -1,0 +1,5 @@
+fr:
+  activerecord:
+    attributes:
+      poll/answer:
+        answer_id: "Réponse"

--- a/config/locales/custom/fr/general.yml
+++ b/config/locales/custom/fr/general.yml
@@ -2,3 +2,24 @@ fr:
   layouts:
     footer:
       consul_url: https://github.com/rockandror/innoviris-consul
+      funding:
+        text: "Ce projet a reçu un financement du programme de recherche et d'innovation Horizon 2020 de l'Union européenne dans le cadre de la convention de subvention n° 872441."
+        logo: "Logo de l'Union européenne"
+      framework:
+        link: "Visitez le cadre Pro-Ethics pro-ethics.eu"
+        logo: "Logo Pro-Ethics"
+  polls:
+    answers:
+      create:
+        success_notice: "Le sondage a été sauvegardé avec succès !"
+      form:
+        submit_button: "Vote"
+        error:
+          one: "1 erreur a empêché l'enregistrement de vos réponses. Veuillez vérifier le champ marqué pour savoir comment le corriger:"
+          other: "%{count} erreurs ont empêché l'enregistrement de vos réponses. Veuillez vérifier les champs marqués pour savoir comment les corriger:"
+        terms_of_service:
+          terms: "En répondant, vous acceptez les %{terms}"
+          title: "En répondant vous acceptez les termes et conditions d'utilisation"
+        postal_code_validator: "Le format du code postal n'est pas valide. Les codes postaux autorisés doivent contenir quatre chiffres."
+    show:
+      answers_descriptions_link_text: "Lire la suite"

--- a/config/locales/custom/it/activerecord.yml
+++ b/config/locales/custom/it/activerecord.yml
@@ -1,0 +1,5 @@
+it:
+  activerecord:
+    attributes:
+      poll/answer:
+        answer_id: "Risposta"

--- a/config/locales/custom/it/general.yml
+++ b/config/locales/custom/it/general.yml
@@ -2,3 +2,24 @@ it:
   layouts:
     footer:
       consul_url: https://github.com/rockandror/innoviris-consul
+      funding:
+        text: "Questo progetto ha ricevuto finanziamenti dal programma di ricerca e innovazione Orizzonte 2020 dell'Unione Europea nell'ambito della convenzione di sovvenzione n. 872441."
+        logo: "Il logo dell'Unione Europea"
+      framework:
+        link: "Visita il framework Pro-Ethics pro-ethics.eu"
+        logo: "Logo Pro-Ethics"
+  polls:
+    answers:
+      create:
+        success_notice: "Sondaggio salvato con successo!"
+      form:
+        submit_button: "Voto"
+        error:
+          one: "1 errore ha impedito il salvataggio delle risposte. Controllare il campo contrassegnato per sapere come correggerlo:"
+          other: "%{count} errori hanno impedito il salvataggio delle risposte. Controllare i campi contrassegnati per sapere come correggerli:"
+        terms_of_service:
+          terms: "Rispondendo accetti i %{terms}"
+          title: "Rispondendo accetti i termini e le condizioni di utilizzo"
+        postal_code_validator: "Il formato del codice postale non è valido. I codici postali consentiti devono contenere quattro cifre."
+    show:
+      answers_descriptions_link_text: "Leggi di più"

--- a/config/locales/custom/nl/activerecord.yml
+++ b/config/locales/custom/nl/activerecord.yml
@@ -1,0 +1,5 @@
+nl:
+  activerecord:
+    attributes:
+      poll/answer:
+        answer_id: "Antwoord"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -2,3 +2,24 @@ nl:
   layouts:
     footer:
       consul_url: https://github.com/rockandror/innoviris-consul
+      funding:
+        text: "Dit project heeft financiering ontvangen van het Horizon 2020-onderzoeks- en innovatieprogramma van de Europese Unie onder subsidieovereenkomst nr. 872441."
+        logo: "Logo van de Europese Unie"
+      framework:
+        link: "Bezoek het Pro-Ethics framework pro-ethics.eu"
+        logo: "Pro-Ethics logo"
+  polls:
+    answers:
+      create:
+        success_notice: "Poll succesvol opgeslagen!"
+      form:
+        submit_button: "Stem"
+        error:
+          one: "1 fout heeft verhinderd dat uw antwoorden werden opgeslagen. Controleer het gemarkeerde veld om te weten hoe u het kunt corrigeren:"
+          other: "%{count} fouten hebben verhinderd dat uw antwoorden werden opgeslagen. Controleer de gemarkeerde velden om te weten hoe u ze kunt corrigeren:"
+        terms_of_service:
+          terms: "Door te antwoorden accepteert u de %{terms}"
+          title: "Door te antwoorden accepteer je de gebruiksvoorwaarden"
+        postal_code_validator: "Het postcodeformaat is ongeldig. Toegestane postcodes moeten vier cijfers bevatten."
+    show:
+      answers_descriptions_link_text: "Lees verder"


### PR DESCRIPTION
## References
During the development of this pilot, we introduced some new messages on public pages.

## Objectives

Translate newly added strings to all the enabled languages.

## Notes
As the new messages introduced are simple we did an initial translation to Arabic, French, Italian and Dutch languages by use an automatic translation tool. Pending to verify texts with Innoviris.
