### PR TITLE
Improve form errors messages readability

### DIFF
--- a/app/assets/stylesheets/_consul_custom_overrides.scss
+++ b/app/assets/stylesheets/_consul_custom_overrides.scss
@@ -13,3 +13,10 @@
 
 $brand: #213b87;
 $brand-secondary: #68c0b5;
+$foundation-palette: (
+  primary: #1779ba,
+  secondary: #767676,
+  success: #3adb76,
+  warning: #ffae00,
+  alert: darken(#cc4b37, 1%),
+) !default;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -109,3 +109,7 @@ body:not(.admin) {
     background-color: $brand-secondary;
   }
 }
+
+.form-error {
+  font-size: $small-font-size;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -13,6 +13,12 @@
   .question-answer-fields {
     margin-bottom: $line-height;
 
+    &.has-error {
+      legend {
+        color: $alert-color;
+      }
+    }
+
     &.single-choice .form-error {
       margin-top: 0;
       margin-bottom: 0;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -12,6 +12,11 @@
 
   .question-answer-fields {
     margin-bottom: $line-height;
+
+    &.single-choice .form-error {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
   }
 
   .question-answer {

--- a/app/components/custom/poll/answers/fields_component.html.erb
+++ b/app/components/custom/poll/answers/fields_component.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= "question_#{question.id}_answer_fields" %>" class="question-answer-fields">
+<div id="<%= "question_#{question.id}_answer_fields" %>" class="<%= styles %>">
   <%= fields_for "question_#{question.id}", answer do |answer_form| %>
     <% if question.single_choice? %>
       <fieldset>

--- a/app/components/custom/poll/answers/fields_component.rb
+++ b/app/components/custom/poll/answers/fields_component.rb
@@ -17,4 +17,10 @@ class Poll::Answers::FieldsComponent < ApplicationComponent
       answer.errors.full_messages_for(field).join(", ")
     end
   end
+
+  def styles
+    classes = %w[question-answer-fields]
+    classes << "single-choice" if answer.question.single_choice?
+    classes.join(" ")
+  end
 end

--- a/app/components/custom/poll/answers/fields_component.rb
+++ b/app/components/custom/poll/answers/fields_component.rb
@@ -21,6 +21,7 @@ class Poll::Answers::FieldsComponent < ApplicationComponent
   def styles
     classes = %w[question-answer-fields]
     classes << "single-choice" if answer.question.single_choice?
+    classes << "has-error" if answer.errors.any?
     classes.join(" ")
   end
 end


### PR DESCRIPTION
## References

Increase form error messages `font-size` and `margin` for single choice questions.

## Objectives

1. Improve readability of error messages.
2. Render single choice legends in red
3. Slightly darken default Foundation's alert color to match WCAG contrast rules

## Visual Changes

Before
<img width="967" alt="Captura de Pantalla 2022-05-26 a las 11 36 06" src="https://user-images.githubusercontent.com/15726/170461587-e49c2090-dce9-4f36-8e47-40fe34b9ccd9.png">


After
<img width="949" alt="Captura de Pantalla 2022-05-26 a las 11 34 41" src="https://user-images.githubusercontent.com/15726/170461619-21c06387-9b07-4a5f-ba60-b4f662ea7b0e.png">

