### PR TITLE
Add a "Terms and conditions" mandatory checkbox to poll answers form

### DIFF
--- a/app/components/custom/poll/answers/form_component.html.erb
+++ b/app/components/custom/poll/answers/form_component.html.erb
@@ -1,8 +1,18 @@
-<%= form_tag answer_poll_path(poll), id: "#{dom_id(poll)}_answers", class: "poll-answers-form" do %>
+<%= form_with model: poll_answers_form, url: answer_poll_path(poll), id: "#{dom_id(poll)}_answers", class: "poll-answers-form" do |f| %>
   <%= invisible_captcha :title %>
   <%= render ErrorsComponent.new(error_message) %>
-  <% answers.each do |answer| %>
+  <% poll_answers_form.answers.each do |answer| %>
     <%= render Poll::Answers::FieldsComponent.new(answer) %>
+  <% end %>
+
+  <% unless poll.voted_by?(current_user) %>
+    <%= f.check_box :terms_of_service,
+      title: t("polls.answers.form.terms_of_service.title"),
+      label: t("polls.answers.form.terms_of_service.terms",
+                terms: link_to(t("devise_views.users.registrations.new.terms_link"), "/conditions",
+                              title: t("shared.target_blank"),
+                              target: "_blank")
+              ) %>
   <% end %>
 
   <%= submit_tag(t("polls.answers.form.submit_button"), class: "button", disabled: cannot?(:answer, poll)) %>

--- a/app/components/custom/poll/answers/form_component.rb
+++ b/app/components/custom/poll/answers/form_component.rb
@@ -1,14 +1,14 @@
 class Poll::Answers::FormComponent < ApplicationComponent
-  attr_reader :answers, :poll
+  attr_reader :poll_answers_form, :poll
   delegate :current_user, :cannot?, to: :helpers
 
-  def initialize(poll, answers)
+  def initialize(poll, poll_answers_form)
     @poll = poll
-    @answers = answers
+    @poll_answers_form = poll_answers_form
   end
 
   def error_message
-    count = answers.select { |a| a.errors.any? }.map(&:errors).flatten.count
+    count = poll_answers_form.errors.count
 
     I18n.t("polls.answers.form.error", count: count) if count > 0
   end

--- a/app/controllers/custom/polls_controller.rb
+++ b/app/controllers/custom/polls_controller.rb
@@ -12,16 +12,14 @@ class PollsController < ApplicationController
   invisible_captcha only: [:answer], honeypot: :title
 
   def show
-    @poll_answers = @questions.map do |question|
+    @poll_answers_form = Poll::AnswersForm.new(answers: @questions.map do |question|
       Poll::Answer.find_or_initialize_by(question: question, author: current_user)
-    end
+    end)
   end
 
   def answer
-    if @poll_answers.map(&:valid?).all?(true)
-      ActiveRecord::Base.transaction do
-        @poll_answers.each(&:save_and_record_voter_participation)
-      end
+    if @poll_answers_form.valid?
+      @poll_answers_form.save!
       redirect_to @poll, notice: t("polls.answers.create.success_notice")
     else
       render :show
@@ -45,7 +43,7 @@ class PollsController < ApplicationController
     end
 
     def set_answers
-      @poll_answers = @questions.map do |question|
+      answers = @questions.map do |question|
         Poll::Answer.find_or_initialize_by(question: question, author: current_user).tap do |answer|
           if question.single_choice?
             answer.answer_id = params.dig("question_#{question.id}", :answer_id)
@@ -54,5 +52,8 @@ class PollsController < ApplicationController
           end
         end
       end
+
+      @poll_answers_form = Poll::AnswersForm.new(answers: answers, terms_of_service:
+        params.dig("poll_answers_form", :terms_of_service))
     end
 end

--- a/app/models/custom/poll/answers_form.rb
+++ b/app/models/custom/poll/answers_form.rb
@@ -1,0 +1,27 @@
+class Poll::AnswersForm
+  include ActiveModel::Validations
+
+  attr_accessor :answers, :terms_of_service
+
+  validates :terms_of_service, acceptance: true
+  validate :validate_answers_and_collect_errors
+
+  def initialize(answers: [], terms_of_service: nil)
+    @answers = answers
+    @terms_of_service = terms_of_service
+  end
+
+  def save!
+    ActiveRecord::Base.transaction do
+      answers.each(&:save_and_record_voter_participation)
+    end
+  end
+
+  private
+
+    def validate_answers_and_collect_errors
+      answers.each(&:valid?)
+
+      errors.add :answers, answers.select { |a| a.errors.any? }.map(&:errors)
+    end
+end

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -31,7 +31,7 @@
         <% end %>
       <% end %>
 
-      <%= render Poll::Answers::FormComponent.new(@poll, @poll_answers) %>
+      <%= render Poll::Answers::FormComponent.new(@poll, @poll_answers_form) %>
     </div>
   </div>
 

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -17,3 +17,6 @@ en:
         error:
           one: "1 error prevented your answers from being saved. Please check the marked field to know how to correct it:"
           other: "%{count} errors prevented your answers from being saved. Please check the marked fields to know how to correct them:"
+        terms_of_service:
+          terms: By answering you accept the %{terms}
+          title: By answering you accept the terms and conditions of use

--- a/spec/models/custom/poll/answers_form_spec.rb
+++ b/spec/models/custom/poll/answers_form_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe Poll::AnswersForm do
+  let(:poll_answers_form) { Poll::AnswersForm.new }
+  let(:question) { create(:poll_question, mandatory_answer: true) }
+  let(:valid_answer_to_question) { build(:poll_answer, question: question, open_answer: "My answer") }
+  let(:invalid_answer_to_question) { build(:poll_answer, question: question, open_answer: "") }
+  let(:single_choice_question) { create(:poll_question, :yes_no, mandatory_answer: true) }
+  let(:valid_answer_to_single_choice_question) do
+    build(:poll_answer, question: single_choice_question,
+                        answer: single_choice_question.question_answers.sample)
+  end
+
+  describe "validations" do
+    it "is valid when terms_of_service is accepted and answers are valid" do
+      poll_answers_form.terms_of_service = "1"
+      poll_answers_form.answers = [valid_answer_to_question, valid_answer_to_single_choice_question]
+
+      expect(poll_answers_form).to be_valid
+    end
+
+    it "is not valid when terms_of_service is accepted but any answer is invalid" do
+      poll_answers_form.terms_of_service = "1"
+      poll_answers_form.answers = [invalid_answer_to_question, valid_answer_to_single_choice_question]
+
+      expect(poll_answers_form).not_to be_valid
+    end
+
+    it "is not valid when terms_of_service is not accepted even with valid answers" do
+      poll_answers_form.terms_of_service = "0"
+      poll_answers_form.answers = [valid_answer_to_question, valid_answer_to_single_choice_question]
+
+      expect(poll_answers_form).not_to be_valid
+    end
+  end
+end

--- a/spec/system/custom/polls/polls_spec.rb
+++ b/spec/system/custom/polls/polls_spec.rb
@@ -16,6 +16,7 @@ describe "Polls" do
       visit poll_path(poll)
 
       choose "Yes"
+      check "By answering you accept the terms and conditions of use"
       click_button "Vote"
 
       expect(page).to have_content("Poll saved successfully!")
@@ -84,6 +85,7 @@ describe "Polls" do
 
       fill_in open_question.title, with: "Open answer to question 1"
       choose "Yes"
+      check "By answering you accept the terms and conditions of use"
       click_button "Vote"
 
       expect(page).to have_content("You have already participated in this poll.")
@@ -102,6 +104,7 @@ describe "Polls" do
       visit poll_path(poll)
 
       choose "Yes"
+      check "By answering you accept the terms and conditions of use"
       click_button "Vote"
 
       expect(page).to have_content("Poll saved successfully!")
@@ -117,6 +120,7 @@ describe "Polls" do
       visit poll_path(poll)
       fill_in open_question.title, with: "Open answer"
       choose "Yes"
+      check "By answering you accept the terms and conditions of use"
       click_button "Vote"
 
       within "#question_#{open_question.id}_answer_fields" do
@@ -196,8 +200,40 @@ describe "Polls" do
 
       click_button "Vote"
 
+      expect(page).to have_content "2 errors prevented your answers from being saved. Please check the " \
+                                   "marked fields to know how to correct them:"
+    end
+
+    scenario "Does not persist user answers when the terms and conditions are not accepted" do
+      create(:poll_question, :yes_no, poll: poll)
+      visit poll_path(poll)
+
+      choose "Yes"
+      click_button "Vote"
+
       expect(page).to have_content "1 error prevented your answers from being saved. Please check the " \
                                    "marked field to know how to correct it:"
+      expect(page).to have_field("Yes", checked: true)
+      expect(page).to have_content "must be accepted"
+    end
+
+    scenario "Does not show and do not require the terms and conditions when updating" do
+      create(:poll_question, :yes_no, poll: poll)
+      visit poll_path(poll)
+
+      expect(page).to have_field("By answering you accept the terms and conditions of use")
+
+      choose "Yes"
+      check "By answering you accept the terms and conditions of use"
+      click_button "Vote"
+
+      expect(page).to have_content("Poll saved successfully!")
+      expect(page).not_to have_field("By answering you accept the terms and conditions of use")
+
+      choose "No"
+      click_button "Vote"
+
+      expect(page).to have_content("Poll saved successfully!")
     end
   end
 end

--- a/spec/system/custom/polls/results_spec.rb
+++ b/spec/system/custom/polls/results_spec.rb
@@ -21,6 +21,7 @@ describe "Poll Results" do
 
     choose "Yes"
     choose "Blue"
+    check "By answering you accept the terms and conditions of use"
     click_button "Vote"
     expect(page).to have_content("Poll saved successfully!")
 
@@ -32,6 +33,7 @@ describe "Poll Results" do
 
     choose "Yes"
     choose "Green"
+    check "By answering you accept the terms and conditions of use"
     click_button "Vote"
 
     expect(page).to have_content("Poll saved successfully!")
@@ -43,6 +45,7 @@ describe "Poll Results" do
 
     choose "No"
     choose "Yellow"
+    check "By answering you accept the terms and conditions of use"
     click_button "Vote"
 
     expect(page).to have_content("Poll saved successfully!")

--- a/spec/system/custom/polls/voter_spec.rb
+++ b/spec/system/custom/polls/voter_spec.rb
@@ -11,6 +11,7 @@ describe "Voter" do
       visit poll_path(poll)
 
       choose "Yes"
+      check "By answering you accept the terms and conditions of use"
       click_button "Vote"
 
       expect(page).to have_content("Poll saved successfully!")


### PR DESCRIPTION
## References
Customer request.

## Objectives

Force users to read and check the terms and conditions page before form submission. The checkbox is only shown during creation, it isn't shown when updating.

## Visual Changes
<img width="953" alt="Captura de Pantalla 2022-05-27 a las 15 35 48" src="https://user-images.githubusercontent.com/15726/170710109-436ef037-9a5a-4272-81de-059d964ed09d.png">



