### PR TITLE
Remove debugger

### DIFF
--- a/spec/models/custom/poll/question_spec.rb
+++ b/spec/models/custom/poll/question_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Poll::Question, type: :model do
 
   describe "#postal_code_validator?" do
     it "returns false when question has no validator" do
-      debugger
       poll_question = create(:poll_question, validator: "none")
 
       expect(poll_question.postal_code_validator?).to be_falsy


### PR DESCRIPTION
## References
Related PR: Allow add format validations to answers #30 

## Objectives
Remove "debugger" on specs.
