### PR TITLE
Remove privacy and accessibility page links on footer

### DIFF
--- a/app/views/custom/layouts/_footer.html.erb
+++ b/app/views/custom/layouts/_footer.html.erb
@@ -26,9 +26,7 @@
     <div class="small-12 medium-8 column">
       <%= t("layouts.footer.copyright", year: Time.current.year) %>&nbsp;|
       <ul class="no-bullet inline-block">
-        <li class="inline-block"><%= link_to t("layouts.footer.privacy"), page_path("privacy") %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.conditions"), page_path("conditions") %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.accessibility"), page_path("accessibility") %></li>
+        <li class="inline-block"><%= link_to t("layouts.footer.conditions"), page_path("conditions") %></li>
       </ul>
     </div>
 


### PR DESCRIPTION
## References
>We noticed you removed the Accessibility and Privacy custom pages. However, the links on the footer are still shown. Do you want us to remove them?

Customer: Indeed, the two pages can be deleted. All privacy info are in terms of conditions.

## Objectives
Remove  privacy and accessibility page links on footer. These pages have been removed and it is no longer necessary to display a link to them in the footer. We only maintain the link to terms and conditions.

## Visual Changes
- Footer without privacy and accessibility links. We only maintain the link to terms and conditions.
![Captura de pantalla 2022-06-10 a las 11 55 43](https://user-images.githubusercontent.com/16189/173041006-1d44fc25-731b-43ad-891d-8a60c1f7346e.png)
